### PR TITLE
Downgrade Parsing Log

### DIFF
--- a/src/uncrustify.cpp
+++ b/src/uncrustify.cpp
@@ -1481,7 +1481,7 @@ static void do_source_file(const char *filename_in,
       cpd.error_count++;
       return;
    }
-   LOG_FMT(LSYS, "Parsing: %s as language %s\n",
+   LOG_FMT(LINFO, "Parsing: %s as language %s\n",
            filename_in, language_name_from_flags(cpd.lang_flags));
 
    cpd.filename = filename_in;


### PR DESCRIPTION
uncrustify prints each file it is parsing at system error level, which is by default printed. For MdeModulePkg along, this creates 1,000 lines of logs, just saying which file is being parsed.

This is noise in the log, so this commit downgrades the print to user information, which is not printed by default.