### PR TITLE
Minor cmake updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,15 +17,8 @@ include(CheckCXXSymbolExists)
 include(CheckTypeSize)
 include(CTest)
 
-if( ${CMAKE_VERSION} VERSION_LESS "3.12" )
-    find_package( PythonInterp )
-    if( NOT PYTHON_EXECUTABLE )
-        message( FATAL_ERROR "Python is required, but was not found on your system" )
-    endif()
- else( )
-    find_package(Python3 REQUIRED)
-    set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE})
-endif()
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
+set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE})
 
 #
 # Check compiler flags
@@ -194,7 +187,7 @@ function(py_gen OUTPUT SCRIPT INPUT)
   add_custom_command(
     OUTPUT "${out}"
     COMMAND ${CMAKE_COMMAND} -E make_directory "${outdir}"
-    COMMAND ${PYTHON_EXECUTABLE}
+    COMMAND Python3::Interpreter
       "${PROJECT_SOURCE_DIR}/scripts/${SCRIPT}"
       "${out}"
       ${deps}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.12)
 
 project(uncrustify)
 

--- a/cmake/GenerateVersionHeader.cmake
+++ b/cmake/GenerateVersionHeader.cmake
@@ -1,11 +1,18 @@
 #
+#!/usr/bin/env cmake
 # Generate uncrustify_version.h from uncrustify_version.h.in
 #
-# This script is meant to be executed with `cmake -P` from a custom target,
-# and expects the variables `PYTHON_EXECUTABLE`, `SOURCE_DIR`, `INPUT`,
-# `OUTPUT` and `UNCRUSTIFY_VERSION` to be set.
-#
+# Executed with `cmake -P` from a custom target.
+# Expects: PYTHON_EXECUTABLE (or Python3_EXECUTABLE), SOURCE_DIR, INPUT,
+# OUTPUT and UNCRUSTIFY_VERSION.
 
+if (NOT DEFINED PYTHON_EXECUTABLE AND DEFINED Python3_EXECUTABLE)
+  set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE})
+endif()
+
+if (NOT DEFINED PYTHON_EXECUTABLE)
+  message(FATAL_ERROR "PYTHON_EXECUTABLE not defined for GenerateVersionHeader.cmake")
+endif()
 
 execute_process(
   COMMAND ${PYTHON_EXECUTABLE} ${SOURCE_DIR}/scripts/make_version.py

--- a/emscripten/CMakeLists.txt
+++ b/emscripten/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.0)
+cmake_minimum_required(VERSION 3.12)
 
 # ------------------------------------------------------------------------------
 

--- a/emscripten/CMakeLists.txt
+++ b/emscripten/CMakeLists.txt
@@ -38,7 +38,8 @@ include(CheckSymbolExists)
 include(CheckCXXSymbolExists)
 include(CheckTypeSize)
 
-find_package(PythonInterp REQUIRED)
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
+set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE})
 
 #
 # Determine config
@@ -153,7 +154,7 @@ function(py_gen OUTPUT SCRIPT INPUT)
   add_custom_command(
     OUTPUT "${out}"
     COMMAND ${CMAKE_COMMAND} -E make_directory "${outdir}"
-    COMMAND ${PYTHON_EXECUTABLE}
+    COMMAND Python3::Interpreter
       "${unc_projdir}/scripts/${SCRIPT}"
       "${out}"
       ${deps}
@@ -191,9 +192,9 @@ py_gen(option_enum.cpp
 FILE(GLOB unc_infiles "${unc_projdir}/src/*.cpp")
 
 ADD_EXECUTABLE(${project_name}
-  ${unc_infiles} 
-  ${unc_projdir}/src/token_enum.h 
-  ${unc_projdir}/src/symbols_table.h 
+  ${unc_infiles}
+  ${unc_projdir}/src/token_enum.h
+  ${unc_projdir}/src/symbols_table.h
   ${unc_projdir}/src/options.h
   ${unc_projdir}/src/option.h
   ${PROJECT_BINARY_DIR}/src/options.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.12)
 
 find_package(Git QUIET)
 


### PR DESCRIPTION
**cmake: raise required version to 3.12**

- macOS GitHub runners no longer provide compatibility for CMake <3.5.
- Update to 3.12 since the build already had conditional logic for
  behavior >=3.12.

---

**cmake: modernize Python usage**

- Replace legacy find_package(PythonInterp) logic with find_package
  (Python3 REQUIRED COMPONENTS Interpreter)
- Expose PYTHON_EXECUTABLE from Python3_EXECUTABLE to improve
  compatibility
- Invoke code generation helpers via imported target
  Python3::Interpreter
- Update GenerateVersionHeader.cmake to gracefully fall back to
  Python3_EXECUTABLE when PYTHON_EXECUTABLE not passed and add
  explicit validation