### PR TITLE
.github: Fix mislabelling of macos-latest arm64 build as x64

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -93,7 +93,7 @@ jobs:
             executable_name: uncrustify.exe
           - os: macos-latest
             build_os: macos
-            target_arch: x64
+            target_arch: arm64
             skip_test: false
             executable_name: uncrustify
     steps:
@@ -259,13 +259,13 @@ jobs:
 
       - name: Organize executables for release
         run: |
-          mkdir -p release/Linux-ARM release/Linux-x86 release/MacOs-x86 release/Windows-ARM release/Windows-x86
+          mkdir -p release/Linux-ARM release/Linux-x86 release/MacOs-ARM release/Windows-ARM release/Windows-x86
           # Linux ARM
           find artifacts/Executable_ubuntu_arm64 -type f -name "uncrustify" -exec cp {} release/Linux-ARM/uncrustify \;
           # Linux x86
           find artifacts/Executable_ubuntu_x64 -type f -name "uncrustify" -exec cp {} release/Linux-x86/uncrustify \;
           # MacOS x86
-          find artifacts/Executable_macos_x64 -type f -name "uncrustify" -exec cp {} release/MacOs-x86/uncrustify \;
+          find artifacts/Executable_macos_arm64 -type f -name "uncrustify" -exec cp {} release/MacOs-ARM/uncrustify \;
           # Windows ARM
           find artifacts/Executable_windows_arm64 -type f -name "uncrustify.exe" -exec cp {} release/Windows-ARM/uncrustify.exe \;
           # Windows x86
@@ -273,7 +273,7 @@ jobs:
 
           chmod +x release/Linux-ARM/uncrustify || true
           chmod +x release/Linux-x86/uncrustify || true
-          chmod +x release/MacOs-x86/uncrustify || true
+          chmod +x release/MacOs-ARM/uncrustify || true
 
       - name: Zip all executables
         run: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -105,8 +105,9 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
+          # Use arm64 python only on macOS; Ubuntu and Windows arm64 builds run on x64 hosts
           python-version: ${{ env.PYTHON_VERSION }}
-          architecture: 'x64'
+          architecture: ${{ matrix.build_os == 'macos' && 'arm64' || 'x64' }}
 
       - name: Set Generator
         id: set-generator


### PR DESCRIPTION
`build-and-test.yml` must have been building the macOS version of Tianocore Uncrustify since a time when `macos-latest` invoked an X64 runner. However, it now invokes an Apple ARM runner. Nothing in 'Build (macOS)' is influenced in any way by the target architecture - except for what it names the output file - so the CI just goes ahead and builds a perfectly good MacOs-ARM version, which it  wrongly publishes as a MacOs-x86 version.

There is believed to be no need to produce a MacOs-x86 version any more (and probably no simple way to), so we just go ahead and fix up naming so that future releases contain a MacOs-ARM version labelled as such.

On building the above version of actions it was noticed (e.g. in 'Copy macOS Executable' step) that an x64 version of python is being used in this build. While this shouldn't matter (and indeed has been producing a perfectly good (I have used it) - if mislabelled - MacOs-ARM build for some time now), it makes more sense to use a native version.

Since Windows and Ubuntu arm64 builds run on x64 hosts, we cannot just follow `matrix.target_arch`; in order to use arm64 python only on macOS we need the slightly more complex logic which is applied here.

Fixes: #7